### PR TITLE
Criando git ignore

### DIFF
--- a/codigo-fonte/.gitignore
+++ b/codigo-fonte/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/codigo-fonte/package.json
+++ b/codigo-fonte/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "bootstrap": "^5.3.3"
+  }
+}


### PR DESCRIPTION
git ignore com node modules e package-lock.json

A instalação do bootstrap via npm cria um arquivo chamado node_modules e um package-lock.json que não devem ser subidos ao github. Pra isso, existe o arquivo .gitignore, que permite que os arquivos dentro dele sejam ignorados.

Uma vez que essa branch seja mergeada, e possível instalar o bootstrap com o comando "npm install". Isso porque o package.json já estará na main.