### PR TITLE
Correção do comportamento do highlight

### DIFF
--- a/codigo-fonte/como-fazer/como-fazer.css
+++ b/codigo-fonte/como-fazer/como-fazer.css
@@ -28,7 +28,7 @@
 }
 
 .menu-lateral div:hover:not(.highlight) {
-    background-color: #23578470;
+    background-color: #23578449;
     transition: background 400ms ease;
 
 }

--- a/codigo-fonte/como-fazer/como-fazer.js
+++ b/codigo-fonte/como-fazer/como-fazer.js
@@ -1,6 +1,15 @@
 const posicao = document.querySelectorAll('section.tutorial > h1');
+const divInicial = document.querySelector('aside.menu-lateral > div[href="#posicao1"]');
+
+if (divInicial) {
+    divInicial.classList.add('highlight');
+}
 
 
+window.addEventListener('load', () => {
+    console.log(posicao);
+    console.log(divInicial);
+})
 
 let posicaoAtualId = '';
 window.addEventListener('scroll', () => {
@@ -11,7 +20,9 @@ window.addEventListener('scroll', () => {
         }
     })
     
+console.log(posicaoAtualId)
     let menuLateral = document.querySelectorAll('aside.menu-lateral > div');
+    console.log(menuLateral);
     menuLateral.forEach(selecionado => {
         if (selecionado.getAttribute('href').slice(1) === posicaoAtualId) {
             selecionado.classList.add('highlight');
@@ -23,4 +34,5 @@ window.addEventListener('scroll', () => {
 
 
 })
+
 


### PR DESCRIPTION
O highlight do menu lateral estava condicionado ao scroll da página. Após essa correção a página carrega e aplica o highlight no primeiro item do menu, antes de qualquer scroll acontecer.

No CSS foi alterada a transparência do hover quando o mouse está sobre os itens do menu.

Consoles.log vão ser removidos numa futura versão, no momento estão presentes para verificação do funcionamento.